### PR TITLE
feature: :seedling: add that size empty check (#15)

### DIFF
--- a/controllers/infrablockspace_controller.go
+++ b/controllers/infrablockspace_controller.go
@@ -219,6 +219,9 @@ func (r *InfraBlockSpaceReconciler) validateKey(key chain.Key) error {
 }
 
 func (r *InfraBlockSpaceReconciler) createChainPVC(ctx context.Context, name, namespace, size, scName string) (ctrl.Result, error) {
+	if size == "" {
+		size = "100Gi"
+	}
 	pvc := chain.CreateChainPVC(name, namespace, size, scName)
 	if err := r.Create(ctx, pvc); err != nil {
 		logger.Error(err)
@@ -232,6 +235,9 @@ func (r *InfraBlockSpaceReconciler) createChainPVC(ctx context.Context, name, na
 	return ctrl.Result{Requeue: true}, nil
 }
 func (r *InfraBlockSpaceReconciler) updateChainPVC(ctx context.Context, name, namespace, size string) (ctrl.Result, error) {
+	if size == "" {
+		return ctrl.Result{}, errors.New("size is required")
+	}
 	foundPVC := &corev1.PersistentVolumeClaim{}
 	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundPVC); err != nil {
 		logger.Error(err)


### PR DESCRIPTION
## DESCRIPTION

## MERGE INFO

### ISSUE NUMBER(JIRA OR GIT)
- #15

### TARGET
- [x] dev
- [ ] master(release)

### TYPE
- [x] FEATURE
- [x] FIX(simple code update)
- [ ] REFACTOR
- [ ] BUG
- [ ] CI/CD
- [ ] DOC

## PROBLEM INFO

### PROBLEM
- When creating a PVC, the value of , size was not supplied and did not fit the regular expression for size in kubernetes.

### SOLUTIONS
- If size is empty, when it is first created, 100Gi is added, and if size is empty during the update, an error occurs.

### BEFORE CODE

createChainPVC
```go
func (r *InfraBlockSpaceReconciler) createChainPVC(ctx context.Context, name, namespace, size, scName string) (ctrl.Result, error) {
	pvc := chain.CreateChainPVC(name, namespace, size, scName)
	if err := r.Create(ctx, pvc); err != nil {
		logger.Error(err)
        ....
	return ctrl.Result{Requeue: true}, nil
}
```

updateChainPVC
```go
func (r *InfraBlockSpaceReconciler) updateChainPVC(ctx context.Context, name, namespace, size string) (ctrl.Result, error) {
	foundPVC := &corev1.PersistentVolumeClaim{}
	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundPVC); err != nil {
		logger.Error(err)
      ....
}
```
### AFTER CODE

createChainPVC
```go
func (r *InfraBlockSpaceReconciler) createChainPVC(ctx context.Context, name, namespace, size, scName string) (ctrl.Result, error) {
	if size == "" {
		size = "100Gi"
	}
	pvc := chain.CreateChainPVC(name, namespace, size, scName)
	if err := r.Create(ctx, pvc); err != nil {
		logger.Error(err)
        ....
	return ctrl.Result{Requeue: true}, nil
}
```

updateChainPVC
```go
func (r *InfraBlockSpaceReconciler) updateChainPVC(ctx context.Context, name, namespace, size string) (ctrl.Result, error) {
	if size == "" {
		return ctrl.Result{}, errors.New("size is required")
	}
	foundPVC := &corev1.PersistentVolumeClaim{}
	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, foundPVC); err != nil {
		logger.Error(err)
      ....
}
```
### ETC
none.