### PR TITLE
17 feat create service resource

### DIFF
--- a/controllers/infrablockspace_controller.go
+++ b/controllers/infrablockspace_controller.go
@@ -380,7 +380,6 @@ func (r *InfraBlockSpaceReconciler) ensureService(ctx context.Context, reqInfraB
 			return ctrl.Result{}, err
 		}
 	}
-	err = r.updateServices(ctx, name, reqInfraBlockSpace)
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/chain/service.go
+++ b/pkg/chain/service.go
@@ -1,0 +1,52 @@
+package chain
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func GetDefaultRelayPorts() []int32 {
+	return []int32{DefaultChainWSPort, DefaultChainRPCPort, DefaultChainP2PPort}
+}
+
+func GetCustomRelayPorts(port Port) []int32 {
+	return []int32{port.WSPort, port.RPCPort, port.P2PPort}
+}
+
+func GenerateClusterIpServiceObject(name, namespace string, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
+	clusterIPService := generateServiceObject(name, namespace, corev1.ServiceTypeClusterIP, ports, selector)
+	return clusterIPService
+}
+
+func GenerateHeadlessServiceObject(name, namespace string, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
+	headlessService := generateServiceObject(name, namespace, corev1.ServiceTypeClusterIP, ports, selector)
+	headlessService.Spec.ClusterIP = corev1.ClusterIPNone
+	return headlessService
+}
+
+func GenerateServicePorts(ports ...int32) []corev1.ServicePort {
+	servicePorts := make([]corev1.ServicePort, len(ports))
+	for _, port := range ports {
+		servicePorts = append(servicePorts, corev1.ServicePort{
+			Port:       port,
+			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: port},
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+	return servicePorts
+}
+
+func generateServiceObject(name, namespace string, serviceType corev1.ServiceType, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
+	return &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Type:     serviceType,
+			Ports:    ports,
+			Selector: selector,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/pkg/chain/service.go
+++ b/pkg/chain/service.go
@@ -1,16 +1,27 @@
 package chain
 
 import (
+	infrablockspacenetv1alpha1 "github.com/InfraBlockchain/infrablockspace-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func GetDefaultRelayPorts() []int32 {
+func GetServicePorts(reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) []int32 {
+	var ports []int32
+	if reqInfraBlockSpace.Spec.Port.WSPort == 0 {
+		ports = getDefaultRelayPorts()
+	} else {
+		ports = getCustomRelayPorts(reqInfraBlockSpace.Spec.Port)
+	}
+	return ports
+}
+
+func getDefaultRelayPorts() []int32 {
 	return []int32{DefaultChainWSPort, DefaultChainRPCPort, DefaultChainP2PPort}
 }
 
-func GetCustomRelayPorts(port Port) []int32 {
+func getCustomRelayPorts(port Port) []int32 {
 	return []int32{port.WSPort, port.RPCPort, port.P2PPort}
 }
 

--- a/pkg/chain/sort.go
+++ b/pkg/chain/sort.go
@@ -1,0 +1,17 @@
+package chain
+
+import corev1 "k8s.io/api/core/v1"
+
+type ServicePortSort []corev1.ServicePort
+
+func (s ServicePortSort) Len() int {
+	return len(s)
+}
+
+func (s ServicePortSort) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ServicePortSort) Less(i, j int) bool {
+	return s[i].Port < s[j].Port
+}

--- a/pkg/chain/spec.go
+++ b/pkg/chain/spec.go
@@ -57,3 +57,16 @@ const InjectKeyScript string = `
            || echo "Failed to insert key into Keystore."
 		{{end}}
 `
+
+const DefaultChainWSPort int32 = 9933
+const DefaultChainRPCPort int32 = 9944
+const DefaultChainP2PPort int32 = 30333
+
+const VolumeSize100Gi = "100Gi"
+const DefaultSecondaryChainWSPort int32 = 9934
+const DefaultSecondaryChainRPCPort int32 = 9945
+const DefaultSecondaryChainP2PPort int32 = 30334
+
+const SuffixService = "service"
+const SuffixPvc = "pvc"
+const SuffixHeadlessService = "headless-service"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,3 +17,21 @@ func TestDecodingBase64(t *testing.T) {
 		assert.Equal(t, "", result)
 	})
 }
+
+func TestEncodingBase64(t *testing.T) {
+	data := []string{"test", "an3", "b"}
+	t.Run("generating name test 1", func(t *testing.T) {
+		result := GenerateResourceName(data...)
+		assert.Equal(t, "test-an3-b", result)
+	})
+	data = []string{"test", "", "b"}
+	t.Run("generating name test 2", func(t *testing.T) {
+		result := GenerateResourceName(data...)
+		assert.Equal(t, "test-b", result)
+	})
+	t.Run("generating name test 3", func(t *testing.T) {
+		result := GenerateResourceName(data...)
+		result = result + "-service"
+		assert.Equal(t, "test-b-service", result)
+	})
+}


### PR DESCRIPTION
## DESCRIPTION

## MERGE INFO

### ISSUE NUMBER(JIRA OR GIT)
- #17 
### TARGET
- [x] dev
- [ ] master(release)

### TYPE
- [x] FEATURE
- [x] FIX(simple code update)
- [x] REFACTOR
- [ ] BUG
- [ ] CI/CD
- [ ] DOC

## PROBLEM INFO

### PROBLEM
- Error when creating statefuleset because service code is missing

### SOLUTIONS
- Implement the ability to create a service object resource

### CHANGE LOG
1. Change from checkXXXXX to ensureXXXX As an example, share statefuleset code
```go
func (r *InfraBlockSpaceReconciler) ensureStatefulSet(ctx context.Context, reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) (ctrl.Result, error) {
	name := util.GenerateResourceName(reqInfraBlockSpace.Name, reqInfraBlockSpace.Spec.Region, reqInfraBlockSpace.Spec.Rack)
	isExists, err := r.checkResourceExists(ctx, reqInfraBlockSpace.Namespace, name, &corev1.PersistentVolumeClaim{})
	if err != nil {
		logger.Error(err)
		return ctrl.Result{}, err
	}
	if !(isExists) {
		return r.createStatefulSet(ctx, name, reqInfraBlockSpace)
	} else {
		return r.updateStatefulSet(ctx, name, reqInfraBlockSpace)
	}
}
```

2. Create an ensureService
```go
func (r *InfraBlockSpaceReconciler) ensureService(ctx context.Context, reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) (ctrl.Result, error) {
	name := util.GenerateResourceName(reqInfraBlockSpace.Name, reqInfraBlockSpace.Spec.Region, reqInfraBlockSpace.Spec.Rack)
	isExists, err := r.checkResourceExists(ctx, reqInfraBlockSpace.Namespace, name, &corev1.Service{})
	if err != nil {
		logger.Error(err)
		return ctrl.Result{}, err
	}
	if !(isExists) {
		if err := r.createServices(ctx, name, reqInfraBlockSpace); err != nil {
			logger.Error(err)
			return ctrl.Result{}, err
		}
	}
	return ctrl.Result{}, nil
}

func (r *InfraBlockSpaceReconciler) createServices(ctx context.Context, name string, reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) error {
	if err := r.createHeadlessService(ctx, name, reqInfraBlockSpace); err != nil {
		return err
	}
	if err := r.createHeadlessService(ctx, name, reqInfraBlockSpace); err != nil {
		return err
	}
	return nil
}

func (r *InfraBlockSpaceReconciler) createHeadlessService(ctx context.Context, name string, reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) error {
	ports := chain.GetServicePorts(reqInfraBlockSpace)
	servicePorts := chain.GenerateServicePorts(ports...)
	service := chain.GenerateHeadlessServiceObject(name+"-"+chain.SuffixHeadlessService, reqInfraBlockSpace.Namespace, servicePorts, nil)
	err := r.createService(ctx, service, reqInfraBlockSpace)
	return err
}

func (r *InfraBlockSpaceReconciler) createService(ctx context.Context, service *corev1.Service, reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) error {
	if err := r.Create(ctx, service); err != nil {
		return err
	}
	_ = ctrl.SetControllerReference(reqInfraBlockSpace, service, r.Scheme)
	logger.Info("created service", zapcore.Field{
		Key:    "Name",
		Type:   zapcore.StringType,
		String: service.Name,
	})
	return nil
}
```

3. Added code to sort ports Implemented for future update functionality
```go
type ServicePortSort []corev1.ServicePort

func (s ServicePortSort) Len() int {
	return len(s)
}

func (s ServicePortSort) Swap(i, j int) {
	s[i], s[j] = s[j], s[i]
}

func (s ServicePortSort) Less(i, j int) bool {
	return s[i].Port < s[j].Port
}
```

4. Implementing service-specific chain package functions
```go
func GetServicePorts(reqInfraBlockSpace *infrablockspacenetv1alpha1.InfraBlockSpace) []int32 {
	var ports []int32
	if reqInfraBlockSpace.Spec.Port.WSPort == 0 {
		ports = getDefaultRelayPorts()
	} else {
		ports = getCustomRelayPorts(reqInfraBlockSpace.Spec.Port)
	}
	return ports
}

func getDefaultRelayPorts() []int32 {
	return []int32{DefaultChainWSPort, DefaultChainRPCPort, DefaultChainP2PPort}
}

func getCustomRelayPorts(port Port) []int32 {
	return []int32{port.WSPort, port.RPCPort, port.P2PPort}
}

func GenerateClusterIpServiceObject(name, namespace string, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
	clusterIPService := generateServiceObject(name, namespace, corev1.ServiceTypeClusterIP, ports, selector)
	return clusterIPService
}

func GenerateHeadlessServiceObject(name, namespace string, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
	headlessService := generateServiceObject(name, namespace, corev1.ServiceTypeClusterIP, ports, selector)
	headlessService.Spec.ClusterIP = corev1.ClusterIPNone
	return headlessService
}

func GenerateServicePorts(ports ...int32) []corev1.ServicePort {
	servicePorts := make([]corev1.ServicePort, len(ports))
	for _, port := range ports {
		servicePorts = append(servicePorts, corev1.ServicePort{
			Port:       port,
			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: port},
			Protocol:   corev1.ProtocolTCP,
		})
	}
	return servicePorts
}

func generateServiceObject(name, namespace string, serviceType corev1.ServiceType, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
	return &corev1.Service{
		Spec: corev1.ServiceSpec{
			Type:     serviceType,
			Ports:    ports,
			Selector: selector,
		},
		ObjectMeta: metav1.ObjectMeta{
			Name:      name,
			Namespace: namespace,
		},
	}
}
```

5. Declaring a chain-specific static variable
```go
const DefaultChainWSPort int32 = 9933
const DefaultChainRPCPort int32 = 9944
const DefaultChainP2PPort int32 = 30333

const VolumeSize100Gi = "100Gi"
const DefaultSecondaryChainWSPort int32 = 9934
const DefaultSecondaryChainRPCPort int32 = 9945
const DefaultSecondaryChainP2PPort int32 = 30334

const SuffixService = "service"
const SuffixPvc = "pvc"
const SuffixHeadlessService = "headless-service"
```

### ETC
None